### PR TITLE
fix: Remove RandomHorizontalFlip from data augmentation

### DIFF
--- a/cubeclassifyer/cube_classifier.py
+++ b/cubeclassifyer/cube_classifier.py
@@ -104,7 +104,6 @@ def get_transforms(train=True):
     if train:
         return transforms.Compose([
             transforms.Resize((240, 320)),  # Resize to 240x320
-            transforms.RandomHorizontalFlip(p=0.5),
             transforms.RandomRotation(degrees=10),
             transforms.ToTensor(),
             # Normalize grayscale images


### PR DESCRIPTION
Removes the `RandomHorizontalFlip` transformation from the training data augmentation pipeline.

This change is made to prevent potential model training issues. If the classification of a cube as 'good' or 'defective' depends on asymmetric features (e.g., a defect that is only on one side), then horizontally flipping the image would be an invalid data augmentation. It would teach the model that the feature's location is irrelevant, potentially leading to poor model performance.

Since the nature of the defects is unknown, this a precautionary measure to ensure the model is not trained with conflicting information.