### PR TITLE
Fix training resume, class weighting, AMP gating, and config wiring

### DIFF
--- a/cubeclassifyer/main.py
+++ b/cubeclassifyer/main.py
@@ -78,8 +78,18 @@ def train_cube_classifier(resume_from=None):
     
     # Create data loaders
     # Use num_workers=0 for compatibility across different systems
-    train_loader = DataLoader(train_dataset, batch_size=16, shuffle=True, num_workers=0)
-    val_loader = DataLoader(val_dataset, batch_size=16, shuffle=False, num_workers=0)
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=config.BATCH_SIZE,
+        shuffle=True,
+        num_workers=config.NUM_WORKERS,
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=config.BATCH_SIZE,
+        shuffle=False,
+        num_workers=config.NUM_WORKERS,
+    )
     
     # Create model
     model = LightweightCubeClassifier(num_classes=config.NUM_CLASSES)
@@ -93,7 +103,16 @@ def train_cube_classifier(resume_from=None):
     logger.info("Starting training...")
 
     # Train model
-    trained_model = train_model(model, train_loader, val_loader, num_epochs=20)
+    trained_model = train_model(
+        model,
+        train_loader,
+        val_loader,
+        num_epochs=config.NUM_EPOCHS,
+        learning_rate=config.LEARNING_RATE,
+        patience=config.PATIENCE,
+        max_grad_norm=config.MAX_GRAD_NORM,
+        resume_from_checkpoint=resume_from,
+    )
 
     print("Training completed! Model saved as 'best_cube_classifier.pth'")
 


### PR DESCRIPTION
### Motivation
- Prevent crashes and incorrect behavior during training resume, class-weight computation, model export, and data loading by fixing ordering, guarding edge cases, and using configuration values.

### Description
- Remove duplicate/unused exception branch in `CubeDataset.__getitem__` to avoid unreachable code and simplify image-fallback handling.
- Initialize `optimizer` and `scheduler` before loading a checkpoint and resume `train_model` from checkpoint reliably by reading `model`/`optimizer`/`scheduler` state after those objects exist (`train_model` in `cube_classifier.py`).
- Guard class-weight computation against zero-count classes by falling back to uniform weights and logging a warning, and compute weights only for non-zero classes (`class_weights` changes in `cube_classifier.py`).
- Gate automatic mixed precision with `config.USE_MIXED_PRECISION` so AMP is enabled only when configured and CUDA is available (`use_amp` change in `cube_classifier.py`).
- Use configured paths and filenames for TorchScript export by saving to `config.TORCHSCRIPT_MODEL_PATH` and logging the actual `output_path` in `convert_model_for_rpi` (`cube_classifier.py`).
- Wire training configuration into `main.py` by using `config.BATCH_SIZE`, `config.NUM_WORKERS` for `DataLoader`, and passing `config.NUM_EPOCHS`, `config.LEARNING_RATE`, `config.PATIENCE`, `config.MAX_GRAD_NORM`, and the `--resume` value into `train_model`.

### Testing
- No automated tests were executed for these changes (no CI/tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696906a257a4832eb59891035d16bb38)