### PR TITLE
fix: update remaining files to 224x224 image size

### DIFF
--- a/cubeclassifyer/README.md
+++ b/cubeclassifyer/README.md
@@ -7,7 +7,7 @@ This project implements a lightweight object detection system to classify cubes 
 1. **Training Environment**: Desktop PC with RTX 3060 Ti
 2. **Model**: Lightweight CNN for grayscale images
 3. **Deployment Target**: Raspberry Pi 5 with 2GB RAM
-4. **Input Format**: 320x240 grayscale images
+4. **Input Format**: 224x224 grayscale images
 
 ## Features
 
@@ -61,7 +61,7 @@ This project implements a lightweight object detection system to classify cubes 
            └── ...
    ```
 
- 3. Ensure all images are 320x240 grayscale images
+ 3. Ensure all images are 224x224 grayscale images (images will be automatically resized)
 
 4. Run the training script:
     ```bash
@@ -132,7 +132,7 @@ Edit `config.py` to customize training parameters:
 <!-- LLM-NOTE: `check_pytorch.py` is a utility script to verify the PyTorch installation. -->
 <!-- LLM-NOTE: The `cube_dataset` directory needs to be created by the user and populated with images. The `main.py` script can create the directory structure. -->
 - **Architecture**: Custom lightweight CNN for grayscale images
-- **Input Size**: 320x240 grayscale images
+- **Input Size**: 224x224 grayscale images
 - **Output**: Classification (good/defective) with confidence score
 - **Model Size**: Optimized for low memory footprint
 
@@ -142,7 +142,7 @@ Edit `config.py` to customize training parameters:
 - Uses TorchScript for optimized inference on the Pi
 - Image preprocessing is optimized for speed
 - Real-time inference capability on Raspberry Pi 5
-- Camera resolution is set to 320x240 for optimal performance
+- Camera resolution is set to 224x224 for optimal performance
 
 ## Customization
 

--- a/cubeclassifyer/benchmark.py
+++ b/cubeclassifyer/benchmark.py
@@ -11,7 +11,7 @@ from cube_classifier import LightweightCubeClassifier
 import os
 
 
-def benchmark_model_inference(model, input_shape=(1, 1, 240, 320), iterations=1000):
+def benchmark_model_inference(model, input_shape=(1, 1, 224, 224), iterations=1000):
     """
     Benchmark model inference speed
 
@@ -183,7 +183,7 @@ def main():
     # Memory usage (if CUDA available)
     if torch.cuda.is_available():
         torch.cuda.reset_peak_memory_stats()
-        dummy_input = torch.randn(1, 1, 240, 320).to(device)
+        dummy_input = torch.randn(1, 1, 224, 224).to(device)
 
         with torch.no_grad():
             _ = model(dummy_input)

--- a/cubeclassifyer/small_dataset_transforms.py
+++ b/cubeclassifyer/small_dataset_transforms.py
@@ -24,7 +24,7 @@ def get_extreme_transforms(train=True):
     """
     # Base transforms (always applied)
     base_transforms = [
-        A.Resize(240, 320),
+        A.Resize(224, 224),
         A.Normalize(mean=[0.5], std=[0.5]),
     ]
 
@@ -128,7 +128,7 @@ def get_moderate_transforms(train=True):
         Composed Albumentations transform
     """
     base_transforms = [
-        A.Resize(240, 320),
+        A.Resize(224, 224),
         A.Normalize(mean=[0.5], std=[0.5]),
     ]
 
@@ -185,7 +185,7 @@ def test_augmentation():
     from PIL import Image
 
     # Create a dummy grayscale image
-    dummy = np.ones((240, 320), dtype=np.uint8) * 200
+    dummy = np.ones((224, 224), dtype=np.uint8) * 200
 
     # Apply transformation
     transform = get_extreme_transforms(train=True)


### PR DESCRIPTION
## Summary
- Updates `benchmark.py` and `small_dataset_transforms.py` to use 224x224 image dimensions
- These files were missed in the previous PR #6

## Changes
| File | Updates |
|------|---------|
| `benchmark.py` | `input_shape` default and `dummy_input` tensor |
| `small_dataset_transforms.py` | `A.Resize()` in both transform functions and test dummy image |

## Verification
```bash
grep -rn "320\|240" cubeclassifyer/*.py
# Should return no results
```